### PR TITLE
Command line option to specify USB device address

### DIFF
--- a/debian/daliserver.default
+++ b/debian/daliserver.default
@@ -2,5 +2,11 @@
 # -n enables testing mode without USB connectivity
 # -l sets the listening address (use 0.0.0.0 to listen on all interfaces)
 # -p changes the port
-DALISERVER_OPTS=""
+# -f sets the log file name
+DALISERVER_OPTS="-f /var/log/daliserver.log"
 
+# Options set based on serial number of DALI USB:
+case "$ID_SERIAL_SHORT" in
+#  000030A1) DALISERVER_OPTS="-p 55826 -f /var/log/daliserver-cellar.log" ;;
+#  0000249A) DALISERVER_OPTS="-p 55827 -f /var/log/daliserver-groundfloor.log" ;;
+esac

--- a/debian/daliserver.upstart
+++ b/debian/daliserver.upstart
@@ -1,0 +1,23 @@
+# daliserver
+# 
+# daliserver is a command multiplexing server for the Tridonic DALI
+# USB adapter, allowing access to a DALI bus from any USB-equipped
+# computer that supports libusb.
+
+description   "Command multiplexing server for Tridonic DALI USB"
+author        "Gregor Riepl <onitake@gmail.com>"
+
+start on usb-device-added ID_MODEL_ID='0020' ID_VENDOR_ID='17b5'
+stop on usb-device-removed ID_MODEL_ID='0020' ID_VENDOR_ID='17b5'
+
+instance daliserver:$BUSNUM:$DEVNUM
+
+respawn
+
+# The device serial number is in ID_SERIAL_SHORT; this can be
+# used in /etc/default/daliserver to set options per device.
+
+script
+  . /etc/default/daliserver
+  exec /usr/bin/daliserver $DALISERVER_OPTS -u $BUSNUM:$DEVNUM
+end script

--- a/debian/init.d
+++ b/debian/init.d
@@ -17,7 +17,7 @@ DESC="DALI USB multiplexer"
 NAME=daliserver
 DAEMON=/usr/bin/$NAME
 PIDFILE=/var/run/$NAME.pid
-DAEMON_ARGS="-f /var/log/daliserver.log -r $PIDFILE -b"
+DAEMON_ARGS="-r $PIDFILE -b"
 SCRIPTNAME=/etc/init.d/$NAME
 VERBOSE=yes
 

--- a/debian/rules
+++ b/debian/rules
@@ -11,3 +11,6 @@
 
 %:
 	dh $@ 
+
+override_dh_installinit:
+	dh_installinit --no-start

--- a/doc/daliserver.1
+++ b/doc/daliserver.1
@@ -12,6 +12,7 @@
 .Op Fl n
 .Op Fl s
 .Op Fl f Ar logfile
+.Op Fl u Ar bus:dev
 .Sh DESCRIPTION
 .Bl -tag
 .It Fl d Ar loglevel
@@ -29,6 +30,8 @@ Enable syslog logging. Only error and fatal messages are logged.
 .It Fl f Ar logfile
 Send log to a file. If debug messages were enabled during compilation, logs
 debug messages. Only info messages otherwise.
+.It Fl u Ar bus:dev
+Specify the USB bus and device number for daliserver to drive.
 .El
 .Sh AUTHORS
 .Bl -item

--- a/lib/usb.h
+++ b/lib/usb.h
@@ -60,7 +60,7 @@ const char *usbdali_error_string(UsbDaliError error);
 // Open the first attached USBDali adapter.
 // Also creates a libusb context if context is NULL.
 // The dispatch queue is mandatory
-UsbDaliPtr usbdali_open(libusb_context *context, DispatchPtr dispatch);
+UsbDaliPtr usbdali_open(libusb_context *context, DispatchPtr dispatch, const char *usbdev);
 // Stop running transfers and close the device, then finalize the libusb context
 // if it was created by usbdali_open.
 void usbdali_close(UsbDaliPtr dali);

--- a/src/daliserver.c
+++ b/src/daliserver.c
@@ -89,6 +89,7 @@ typedef struct {
 	char *logfile;
 	int background;
 	char *pidfile;
+	char *usbdev;
 } Options;
 
 static IpcPtr killsocket;
@@ -139,7 +140,7 @@ int main(int argc, char *const argv[]) {
 	UsbDaliPtr usb = NULL;
 	if (!opts->dryrun) {
 		log_debug("Initializing USB connection");
-		usb = usbdali_open(NULL, dispatch);
+		usb = usbdali_open(NULL, dispatch, opts->usbdev);
 		if (!usb) {
 			return -1;
 		}
@@ -267,10 +268,11 @@ static Options *parse_opt(int argc, char *const argv[]) {
 	opts->logfile = NULL;
 	opts->background = 0;
 	opts->pidfile = NULL;
+	opts->usbdev = NULL;
 
 	int opt;
 	opterr = 0;
-	while ((opt = getopt(argc, argv, "d:l:p:nsf:br:")) != -1) {
+	while ((opt = getopt(argc, argv, "d:l:p:nsf:br:u:")) != -1) {
 		switch (opt) {
 		case 'd':
 			if (strcmp(optarg, "fatal") == 0) {
@@ -316,6 +318,9 @@ static Options *parse_opt(int argc, char *const argv[]) {
 			free(opts->pidfile);
 			opts->pidfile = strdup(optarg);
 			break;
+		case 'u':
+			opts->usbdev = strdup(optarg);
+			break;
 		default:
 			free_opt(opts);
 			return NULL;
@@ -354,6 +359,7 @@ static void show_help() {
 	}
 	fprintf(stderr, "-b            Fork into background (implies -r)\n");
 	fprintf(stderr, "-r <file>     Save PID to file (default=/var/run/daliserver.pid)\n");
+	fprintf(stderr, "-u <bus:dev>  Only drive the USB device at bus:dev\n");
 	fprintf(stderr, "\n");
 }
 


### PR DESCRIPTION
I have a system that I need to connect two DALI USB devices to.  I would like to be able to run two copies of daliserver, each listening on a different port, such that the mapping between port number and physical DALI USB device is consistent.

This patch seems to be the minimal change necessary to support this.  It adds a new command-line option, "-u", that takes a colon-separated bus:device address string as an argument.  If this option is specified, daliserver will only drive a DALI USB device if it is found at that address.  If the option is not specified, daliserver's behaviour is unchanged.

The script that starts daliserver can read the serial number from the DALI USB device, and use a lookup table of serial numbers to port numbers to start daliserver with appropriate -p and -u options.
