### PR TITLE
Add Perl example for setting color temperature (DT8)

### DIFF
--- a/perl/lamptemp.pl
+++ b/perl/lamptemp.pl
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use usbdali;
+use Data::Dumper;
+
+if (@ARGV < 2) {
+	print("Usage: lamptemp.pl <0-63> <1000-20000>\n");
+	exit(1);
+}
+
+my $lamp = $ARGV[0];
+my $temp = $ARGV[1];
+if ($lamp < 0) {
+	$lamp = 0;
+}
+if ($lamp > 63) {
+	$lamp = 63;
+}
+if ($temp < 1000) {
+	$temp = 0;
+}
+if ($temp > 20000) {
+	$temp = 20000;
+}
+
+my $mirek = int(1000000 / $temp);
+my $mirek_lsb = $mirek & 0xff;
+my $mirek_msb = ($mirek >> 8) & 0xff;
+print("Setting color temperature to $temp K ($mirek Mirek)\n");
+
+my $dali = usbdali->new('localhost');
+if ($dali->connect()) {
+	$dali->send(usbdali->make_cmd('special', 'dtr0', $mirek_lsb));
+	$dali->send(usbdali->make_cmd('special', 'dtr1', $mirek_msb));
+	$dali->send(usbdali->make_cmd('special', 'type', 8));
+	$dali->send(usbdali->make_cmd('lamp', $lamp, 'temperature'));
+	my $resp = $dali->receive();
+	if ($resp) {
+		if ($resp->{status} eq 'response') {
+			print("Received status:$resp->{status} response:$resp->{response}\n");
+		} else {
+			print("Received status:$resp->{status}\n");
+		}
+	} else {
+		print("Receive error\n");
+	}
+	$dali->disconnect();
+} else {
+	print("Can't connect\n");
+}

--- a/perl/usbdali.pm
+++ b/perl/usbdali.pm
@@ -202,7 +202,7 @@ sub make_cmd {
 					$code0 = 0xa1;
 					$code1 = 0x00;
 				}
-				when (/dtr/) {
+				when (/dtr0/) {
 					$code0 = 0xa3;
 					$code1 = $cmd & 0xff;
 				}
@@ -249,6 +249,18 @@ sub make_cmd {
 				when (/phys/) {
 					$code0 = 0xbd;
 					$code1 = 0x00;
+				}
+				when (/type/) {
+					$code0 = 0xc1;
+					$code1 = $cmd & 0xff;
+				}
+				when (/dtr1/) {
+					$code0 = 0xc3;
+					$code1 = $cmd & 0xff;
+				}
+				when (/dtr2/) {
+					$code0 = 0xc5;
+					$code1 = $cmd & 0xff;
 				}
 				default {
 					$code0 = 0x00;
@@ -405,6 +417,9 @@ sub make_cmd {
 		}
 		when (/randoml/) {
 			$code = 0xc4;
+		}
+		when (/temperature/) {
+			$code = 0xe7;
 		}
 		default {
 			$code = 0x00;


### PR DESCRIPTION
Adds the "Set Temporary Color Temperature Tc" command to the list and implements an example script for changing the color temperature of a simple lamp.

Only supports DT8 devices, i.e. those using DTR registers to change Tc.

Thanks to: https://electronics.stackexchange.com/questions/604979/dali-209-device-type-8-cct-control