### PR TITLE
feat: implement support for logrotate

### DIFF
--- a/debian/daliserver.logrotate
+++ b/debian/daliserver.logrotate
@@ -1,0 +1,13 @@
+/var/log/daliserver.log
+{
+	rotate 7
+	daily
+	missingok
+	notifempty
+	compress
+	delaycompress
+	sharedscripts
+	postrotate
+		/usr/bin/killall -HUP daliserver
+	endscript
+}

--- a/lib/dispatch.c
+++ b/lib/dispatch.c
@@ -73,7 +73,7 @@ DispatchStatus dispatch_run(DispatchPtr table, int timeout) {
 			if (errno != EINTR) {
 				log_error("Error waiting for I/O events");
 			}
-			return 0;
+			return 1;
 		} else if (ready == 0) {
 			// timeout
 			log_debug("poll() timeout");

--- a/lib/log.c
+++ b/lib/log.c
@@ -177,9 +177,9 @@ int log_reopen_file() {
 }
 
 int log_set_logfile(const char *logfile_path) {
-	if (logfile_path == NULL) {
-		logfile = NULL;
-	} else {
+	free(logfile);
+	logfile = NULL;
+	if (logfile_path != NULL) {
 		logfile = strdup(logfile_path);
 		if (!logfile) {
 			log_error("Error setting log file %s: %s", logfile_path, strerror(errno));

--- a/lib/log.c
+++ b/lib/log.c
@@ -45,6 +45,7 @@
 static unsigned int loglevel = LOG_LEVEL_DEFAULT;
 static unsigned int loglevel_file = LOG_LEVEL_DEFAULT;
 static unsigned int loglevel_syslog = LOG_LEVEL_ERROR;
+static char *logfile = NULL;
 static FILE *fp_logfile = NULL;
 static int enabled_syslog = 0;
 
@@ -155,7 +156,11 @@ unsigned int log_get_level() {
 	return loglevel;
 }
 
-int log_set_logfile(const char *logfile) {
+int log_reopen_file() {
+	if (fp_logfile) {
+		fclose(fp_logfile);
+		fp_logfile = NULL;
+	}
 	if (logfile) {
 		FILE *fp = fopen(logfile, "a");
 		if (!fp) {
@@ -167,13 +172,21 @@ int log_set_logfile(const char *logfile) {
 			}
 			fp_logfile = fp;
 		}
-	} else {
-		if (fp_logfile) {
-			fclose(fp_logfile);
-			fp_logfile = NULL;
-		}
 	}
 	return 0;
+}
+
+int log_set_logfile(const char *logfile_path) {
+	if (logfile_path == NULL) {
+		logfile = NULL;
+	} else {
+		logfile = strdup(logfile_path);
+		if (!logfile) {
+			log_error("Error setting log file %s: %s", logfile_path, strerror(errno));
+			return -1;
+		}
+	}
+	return log_reopen_file();
 }
 
 void log_set_logfile_level(unsigned int level) {

--- a/lib/log.c
+++ b/lib/log.c
@@ -162,15 +162,10 @@ int log_reopen_file() {
 		fp_logfile = NULL;
 	}
 	if (logfile) {
-		FILE *fp = fopen(logfile, "a");
-		if (!fp) {
+		fp_logfile = fopen(logfile, "a");
+		if (!fp_logfile) {
 			log_error("Error opening log file %s: %s", logfile, strerror(errno));
 			return -1;
-		} else {
-			if (fp_logfile) {
-				fclose(fp_logfile);
-			}
-			fp_logfile = fp;
 		}
 	}
 	return 0;

--- a/lib/log.h
+++ b/lib/log.h
@@ -51,11 +51,15 @@ void log_printf(unsigned int level, const char *format, ...);
 void log_set_level(unsigned int level);
 // Gets the current log level
 unsigned int log_get_level();
+// Reopen the configured log file (if any), e.g. after logrotate
+// Returns 0 upon success, -1 if the file could not be opened
+// (also generates a warning to the other logging channels in this case)
+int log_reopen_file();
 // Enables/disables logging to a log file
 // Pass NULL for logfile to disable
 // Returns 0 upon success, -1 if the file could not be opened
 // (also generates a warning to the other logging channels in this case)
-int log_set_logfile(const char *logfile);
+int log_set_logfile(const char *logfile_path);
 // Set the log level for the logfile
 // The default is the same as for console logging
 void log_set_logfile_level(unsigned int level);

--- a/src/daliserver.c
+++ b/src/daliserver.c
@@ -177,6 +177,7 @@ int main(int argc, char *const argv[]) {
 					running = 1;
 					signal(SIGTERM, signal_handler);
 					signal(SIGINT, signal_handler);
+					signal(SIGHUP, signal_handler);
 					while (running && dispatch_run(dispatch, usbdali_get_timeout(usb)));
 
 					log_info("Shutting daliserver down");
@@ -201,6 +202,11 @@ int main(int argc, char *const argv[]) {
 }
 
 static void signal_handler(int sig) {
+	if (sig == SIGHUP) {
+		log_info("Signal received, reopening log file");
+		log_reopen_file();
+		return;
+	}
 	if (running) {
 		log_info("Signal received, shutting down");
 		running = 0;


### PR DESCRIPTION
When daliserver writes a logfile, the logfile is never rotated and keeps on growing. On our system it has now reached ~6GB. This ended up filling the disk of our backup server, as we do daily backups with file-level deduplication: As the file was constantly appended to, it was never the same file, and every incremental backup contained a full copy of this file.

While trying to set up a logrotate config, I realized that daliserver did not yet contain any logic for re-opening the logfile, which is requried for logrotate to work. So this PR contains two things:
- A logrotate config for the Debian package that signals the `daliserver` process with `SIGHUP` after log rotation
- A signal handler for `SIGHUP` that re-opens the logfile by name.