### PR TITLE
fix(debian): systemd unit cli args interpolation

### DIFF
--- a/debian/daliserver.service
+++ b/debian/daliserver.service
@@ -4,7 +4,7 @@ Description=DALI USB adapter multiplexer
 [Service]
 # see the defaults file for useful options
 EnvironmentFile=-/etc/default/daliserver
-ExecStart=/usr/bin/daliserver ${DALISERVER_OPTS}
+ExecStart=/usr/bin/daliserver $DALISERVER_OPTS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
My `/etc/default/daliserver`:
```ini
DALISERVER_OPTS="-l 0.0.0.0 -p 55825"
```

With `${DALISERVER_OPTS}` in the systemd unit (daliserver 0.4):
```
Feb 13 02:32:27 smartspace01 systemd[1]: Started daliserver.service - DALI USB adapter multiplexer.
Feb 13 02:32:27 smartspace01 daliserver[1800641]: DALI USB multiplexer (daliserver)
Feb 13 02:32:27 smartspace01 daliserver[1800641]: Copyright (c) 2011 onitake All rights reserved.
Feb 13 02:32:27 smartspace01 daliserver[1800641]: [2024-02-13 02:32:27] INFO Starting daliserver
Feb 13 02:32:27 smartspace01 daliserver[1800641]: [2024-02-13 02:32:27] INFO Kernel driver is active, trying to detach
Feb 13 02:32:27 smartspace01 daliserver[1800641]: [2024-02-13 02:32:27] **ERROR** Error converting address: Resource temporarily unavailable
Feb 13 02:32:27 smartspace01 daliserver[1800641]: Error converting address: Resource temporarily unavailable
Feb 13 02:32:27 smartspace01 daliserver[1800641]: [2024-02-13 02:32:27] INFO Reattaching kernel driver
Feb 13 02:32:27 smartspace01 daliserver[1800641]: [2024-02-13 02:32:27] INFO Exiting
Feb 13 02:32:27 smartspace01 systemd[1]: daliserver.service: Main process exited, code=exited, status=255/EXCEPTION
Feb 13 02:32:27 smartspace01 systemd[1]: daliserver.service: Failed with result 'exit-code'.
```

With `$DALISERVER_OPTS` in the systemd unit (this PR):

```
Feb 13 02:48:40 smartspace01 systemd[1]: Started daliserver.service - DALI USB adapter multiplexer.
Feb 13 02:48:40 smartspace01 daliserver[1801501]: DALI USB multiplexer (daliserver)
Feb 13 02:48:40 smartspace01 daliserver[1801501]: Copyright (c) 2011 onitake All rights reserved.
Feb 13 02:48:40 smartspace01 daliserver[1801501]: [2024-02-13 02:48:40] INFO Starting daliserver
Feb 13 02:48:40 smartspace01 daliserver[1801501]: [2024-02-13 02:48:40] INFO Kernel driver is active, trying to detach
Feb 13 02:48:40 smartspace01 daliserver[1801501]: [2024-02-13 02:48:40] INFO Server ready, waiting for events
```

The reason behind this is that with `${}`, systemd passes the contents of the `DALISERVER_OPTS` value as a single argument, whereas with `$` it doesn't.

Further info in `man 5 systemd.service`:

```
       Basic environment variable substitution is supported. Use "${FOO}" as
       part of a word, or as a word of its own, on the command line, in which
       case it will be erased and replaced by the exact value of the
       environment variable (if any) including all whitespace it contains,
       always resulting in exactly a single argument. Use "$FOO" as a separate
       word on the command line, in which case it will be replaced by the
       value of the environment variable split at whitespace, resulting in
       zero or more arguments. For this type of expansion, quotes are
       respected when splitting into words, and afterwards removed.
```